### PR TITLE
Add np.mean as option for flow_downstream

### DIFF
--- a/src/earthkit/hydro/accumulation.py
+++ b/src/earthkit/hydro/accumulation.py
@@ -44,10 +44,26 @@ def flow_downstream(
         else:
             op = _ufunc_to_downstream_missing_values_ND
 
-    def operation(river_network, field, grouping, mv):
-        return op(river_network, field, grouping, mv, ufunc=ufunc)
+    if ufunc is np.mean:
 
-    return flow(river_network, field, False, operation, mv)
+        def operation(river_network, field, grouping, mv):
+            return op(river_network, field, grouping, mv, ufunc=np.add)
+
+        flow(river_network, field, False, operation, mv)
+
+        counts = np.ones(field.shape)
+        flow(river_network, counts, False, operation, mv)
+
+        field /= counts
+
+        return field
+
+    else:
+
+        def operation(river_network, field, grouping, mv):
+            return op(river_network, field, grouping, mv, ufunc=ufunc)
+
+        return flow(river_network, field, False, operation, mv)
 
 
 def _ufunc_to_downstream(river_network, field, grouping, mv, ufunc):


### PR DESCRIPTION
The function
`flow_downstream(river_network, field, mv=np.nan, in_place=False, ufunc=np.add, accept_missing=False)`
only accepts numpy ufuncs, of which np.mean is not one.

However, wanting to compute means over catchments is a very common use case. This PR allows for the use of ufunc=np.mean i.e. `flow_downstream(river_network, field, ufunc=np.mean)`