### PR TITLE
Add Sphinx documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,7 @@
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = _build
+
+html:
+	$(SPHINXBUILD) -M html $(SOURCEDIR) $(BUILDDIR)
+.PHONY: html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=4
+sphinxcontrib-autoprogram
+sphinx_rtd_theme

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,30 @@
+API Reference
+=============
+
+.. currentmodule:: earthkit.hydro
+
+Functions
+---------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+
+   flow_downstream
+   flow_upstream
+   calculate_catchment_metric
+   find_catchments
+   calculate_downstream_metric
+   move_downstream
+   move_upstream
+   create_river_network
+   load_river_network
+   calculate_subcatchment_metric
+   find_subcatchments
+   calculate_upstream_metric
+   calculate_zonal_metric
+
+.. automodule:: earthkit.hydro
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,22 +7,22 @@ Functions
 ---------
 
 .. autosummary::
-   :toctree: generated
-   :nosignatures:
+    :toctree: generated
+    :nosignatures:
 
-   flow_downstream
-   flow_upstream
-   calculate_catchment_metric
-   find_catchments
-   calculate_downstream_metric
-   move_downstream
-   move_upstream
-   create_river_network
-   load_river_network
-   calculate_subcatchment_metric
-   find_subcatchments
-   calculate_upstream_metric
-   calculate_zonal_metric
+    flow_downstream
+    flow_upstream
+    calculate_catchment_metric
+    find_catchments
+    calculate_downstream_metric
+    move_downstream
+    move_upstream
+    create_river_network
+    load_river_network
+    calculate_subcatchment_metric
+    find_subcatchments
+    calculate_upstream_metric
+    calculate_zonal_metric
 
 .. automodule:: earthkit.hydro
     :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,15 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../src'))
+project = 'earthkit-hydro'
+author = 'ECMWF'
+release = '0.1'
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+]
+templates_path = ['_templates']
+exclude_patterns = []
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,15 +1,17 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../src'))
-project = 'earthkit-hydro'
-author = 'ECMWF'
-release = '0.1'
+
+sys.path.insert(0, os.path.abspath("../../src"))
+project = "earthkit-hydro"
+author = "ECMWF"
+release = "0.1"
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosummary",
 ]
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,10 @@
+Welcome to earthkit-hydro's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   overview
+   user_guide
+   api

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1,0 +1,17 @@
+Overview
+========
+
+``earthkit-hydro`` is a Python library for common hydrological functions. It supports
+river networks such as PCRaster, CaMa-Flood and HydroSHEDS and provides tools for
+computing statistics over catchments, subcatchments or arbitrary zones.
+
+Installation
+------------
+
+Install the package using pip:
+
+.. code-block:: bash
+
+   pip install earthkit-hydro
+
+For development instructions see the project ``README``.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -94,7 +94,7 @@ Convenience helpers ``distance.to_source`` and ``distance.to_sink`` (and their
 sinks.
 
 Moving Fields Upstream and Downstream
-------------------------------------
+-------------------------------------
 
 Fields can be propagated along a river network using ``move_downstream`` or
 ``move_upstream``. This updates each node with the value from the connected

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,0 +1,119 @@
+User Guide
+==========
+
+This section walks through a typical workflow using :mod:`earthkit.hydro`. It is
+based on the ``docs/notebooks/example.ipynb`` notebook.
+
+Fields and River Networks
+-------------------------
+
+A river network is defined on a grid. All fields passed to ``earthkit-hydro``
+should be on the same grid. Multidimensional fields are also supported, with the
+last two axes representing the grid.
+
+River Network Creation
+----------------------
+
+Precomputed networks can be listed using ``river_network.available()`` and loaded
+with ``river_network.load``:
+
+.. code-block:: python
+
+   import earthkit.hydro as ekh
+
+   # list available networks
+   ekh.river_network.available()
+
+   # load the EFAS v5 river network
+   rn = ekh.river_network.load(domain="efas", river_network_version="5")
+
+Upstream Metrics
+----------------
+
+Given a river network, upstream metrics can be computed via the
+:mod:`earthkit.hydro.upstream` module:
+
+.. code-block:: python
+
+   result = ekh.upstream.sum(rn, field)
+
+Other functions such as ``mean``, ``max`` and ``min`` are available. Lower level
+access is provided by ``calculate_upstream_metric``.
+
+Finding Catchments and Subcatchments
+------------------------------------
+
+Catchments or subcatchments defined by points can be found with
+``catchments.find`` or ``subcatchments.find``:
+
+.. code-block:: python
+
+   catchments = ekh.catchments.find(rn, points)
+   subcatchments = ekh.subcatchments.find(rn, points)
+
+Computing Subcatchment Metrics
+------------------------------
+
+Metrics over the subcatchments of given points are computed using the
+``subcatchments`` module:
+
+.. code-block:: python
+
+   values = ekh.subcatchments.mean(rn, field, points)
+
+Zonal Metrics
+-------------
+
+For arbitrary areas not defined by a catchment, ``zonal.*`` functions compute a
+metric over labelled zones:
+
+.. code-block:: python
+
+   zone_values = ekh.zonal.mean(field, labels)
+
+For more details and visual examples, see ``docs/notebooks/example.ipynb``.
+
+Distances and Lengths
+---------------------
+
+Distances or lengths along a river network can be computed with the
+:mod:`earthkit.hydro.distance` and :mod:`earthkit.hydro.length` modules. The
+``min`` and ``max`` functions take a river network, a set of points and optional
+weights representing the distance (or length) to the downstream cell.
+
+.. code-block:: python
+
+   # minimum upstream distance from ``points``
+   dist = ekh.distance.min(rn, points, upstream=True, downstream=False)
+
+   # maximum downstream length using predefined cell lengths
+   length = ekh.length.max(rn, points, weights)
+
+Convenience helpers ``distance.to_source`` and ``distance.to_sink`` (and their
+``length`` counterparts) compute shortest or longest paths to all sources or
+sinks.
+
+Moving Fields Upstream and Downstream
+------------------------------------
+
+Fields can be propagated along a river network using ``move_downstream`` or
+``move_upstream``. This updates each node with the value from the connected
+upstream or downstream node.
+
+.. code-block:: python
+
+   downstream_field = ekh.move_downstream(rn, field)
+   upstream_field = ekh.move_upstream(rn, field)
+
+Flow Accumulation
+-----------------
+
+For more advanced operations one can apply an arbitrary ``ufunc`` along the
+network using ``flow_downstream`` or ``flow_upstream``. This is a generalisation
+of the upstream and downstream metric routines.
+
+.. code-block:: python
+
+   accumulated = ekh.flow_downstream(rn, field, ufunc=np.add)
+
+These functions underlie the higher level metric helpers discussed above.


### PR DESCRIPTION
## Summary
- add a simple Sphinx configuration in `docs`
- document an overview of the project
- add a user guide that summarises the example notebook
- add API reference using autodoc
- extend the user guide with distance, length and movement examples
- list all public functions in the API page

## Testing
- `pytest -q`
- `make -C docs html` *(fails: sphinx-build: command not found)*