### PR TITLE
not local paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@
 
 <table>
   <tr>
-    <td><img src="./docs/images/glofas.png" height="300" alt="Adapted from: doc_figure" /></td>
-    <td><img src="./docs/images/array_backends_with_xr.png" height="300" alt="Array backends with xr" /></td>
+    <td><img src="https://raw.githubusercontent.com/ecmwf/earthkit-hydro/refs/tags/1.0.0/docs/images/glofas.png" height="300" alt="Adapted from: doc_figure" /></td>
+    <td><img src="https://raw.githubusercontent.com/ecmwf/earthkit-hydro/refs/tags/1.0.0/docs/images/array_backends_with_xr.png" height="300" alt="Array backends with xr" /></td>
   </tr>
 </table>
 


### PR DESCRIPTION
### Description
PyPI has issues displaying images based on local paths in the README, so this removes any local paths. Close #127.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 