### PR TITLE
Feat/array backend tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ dependencies = [
     ]
     tests = [
         "pytest",
+        "torch",
+        "tensorflow",
+        "jax",
+        "mlx"
         ]
     dev = [
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,11 @@ dependencies = [
     all = [
         "earthkit-data[geotiff]>=0.13.8",
         "pytest",
-        "pre-commit"
+        "pre-commit",
+        "torch",
+        "tensorflow",
+        "jax",
+        "mlx[cpu]"
         ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
         "torch",
         "tensorflow",
         "jax",
-        "mlx"
+        "mlx[cpu]"
         ]
     dev = [
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
         "torch",
         "tensorflow",
         "jax",
-        "mlx[cpu]"
         ]
     dev = [
         "pytest",
@@ -76,7 +75,6 @@ dependencies = [
         "torch",
         "tensorflow",
         "jax",
-        "mlx[cpu]"
         ]
 
 [tool.black]

--- a/src/earthkit/hydro/_backends/mlx_backend.py
+++ b/src/earthkit/hydro/_backends/mlx_backend.py
@@ -9,13 +9,17 @@ class MLXBackend(ArrayBackend):
 
     @property
     def name(self):
-        return "cupy"
+        return "mlx"
 
     def copy(self, x):
         return x
 
     def asarray(self, x, *args, **kwargs):
         return mx.array(x)
+
+    def full(self, *args, **kwargs):
+        kwargs.pop("device")
+        return mx.full(*args, **kwargs)
 
     def gather(self, arr, indices, axis=-1):
         assert axis == -1

--- a/src/earthkit/hydro/_backends/tensorflow_backend.py
+++ b/src/earthkit/hydro/_backends/tensorflow_backend.py
@@ -68,15 +68,25 @@ class TFBackend(ArrayBackend):
     def gather(self, arr, indices, axis=-1):
         return tf.gather(arr, indices, axis=axis)
 
-    def full_like(self, arr, value):
-        return tf.fill(tf.shape(arr), value)
+    def full_like(self, arr, value, *args, **kwargs):
+        return tf.fill(tf.shape(arr), value, *args, **kwargs)
 
-    def full(self, shape, value):
-        return tf.fill(shape, value)
+    def full(self, shape, value, *args, **kwargs):
+        kwargs.pop("device")
+        dtype = kwargs.pop("dtype")
+        out = tf.fill(shape, value, *args, **kwargs)
+        if dtype:
+            return tf.cast(out, dtype)
+        else:
+            return out
 
     @property
     def nan(self):
         return float("nan")
+
+    @property
+    def inf(self):
+        return float("inf")
 
     def asarray(self, arr, dtype=None, device=None, copy=None):
         tensor = tf.convert_to_tensor(arr, dtype=dtype)

--- a/src/earthkit/hydro/_utils/decorators/masking.py
+++ b/src/earthkit/hydro/_utils/decorators/masking.py
@@ -56,7 +56,7 @@ def scatter_and_reshape(xp, mask, out_1d, target_shape, device):
     B = target_shape[:-2]
     M, N = target_shape[-2], target_shape[-1]
     flat_shape = B + (M * N,)
-    out_flat = xp.full(flat_shape, xp.nan, device=device)
+    out_flat = xp.full(flat_shape, xp.nan, device=device, dtype=out_1d.dtype)
     out_flat = xp.scatter_assign(out_flat, mask, out_1d)
     return xp.reshape(out_flat, target_shape)
 

--- a/tests/test_accumulation.py
+++ b/tests/test_accumulation.py
@@ -77,14 +77,23 @@ def get_numpy_function(function_name):
     ],
     indirect=["river_network"],
 )
-def test_upstream_metric_sum(river_network, input_field, flow_downstream, mv):
+@pytest.mark.parametrize(
+    "array_backend", ["numpy", "torch", "jax", "mlx", "tensorflow"]
+)
+def test_upstream_metric_sum(
+    river_network, input_field, flow_downstream, mv, array_backend
+):
+    river_network = river_network.to_device("cpu", array_backend)
+    xp = ekh._backends.find.get_array_backend(array_backend)
     output_field = ekh.upstream.array.sum(
-        river_network, input_field, node_weights=None, return_type="masked"
+        river_network, xp.asarray(input_field), node_weights=None, return_type="masked"
     )
+    output_field = np.asarray(output_field)
+    flow_downstream_out = np.asarray(xp.asarray(flow_downstream))
     print(output_field)
-    print(flow_downstream)
-    assert output_field.dtype == flow_downstream.dtype
-    np.testing.assert_allclose(output_field, flow_downstream)
+    print(flow_downstream_out)
+    assert output_field.dtype == flow_downstream_out.dtype
+    np.testing.assert_allclose(output_field, flow_downstream, rtol=1e-6)
 
     print(input_field)
     input_field = convert_to_2d(river_network, input_field, 0)
@@ -92,12 +101,14 @@ def test_upstream_metric_sum(river_network, input_field, flow_downstream, mv):
     print(mv, input_field.dtype)
     print(input_field, flow_downstream)
     output_field = ekh.upstream.array.sum(
-        river_network, input_field, node_weights=None
-    ).flatten()
+        river_network, xp.asarray(input_field), node_weights=None
+    )
+    output_field = np.asarray(output_field).flatten()
+    flow_downstream = np.asarray(xp.asarray(flow_downstream))
     print(output_field)
     print(flow_downstream)
     assert output_field.dtype == flow_downstream.dtype
-    np.testing.assert_allclose(output_field, flow_downstream)
+    np.testing.assert_allclose(output_field, flow_downstream, rtol=1e-6)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_accumulation.py
+++ b/tests/test_accumulation.py
@@ -77,9 +77,7 @@ def get_numpy_function(function_name):
     ],
     indirect=["river_network"],
 )
-@pytest.mark.parametrize(
-    "array_backend", ["numpy", "torch", "jax", "mlx", "tensorflow"]
-)
+@pytest.mark.parametrize("array_backend", ["numpy", "torch", "jax", "tensorflow"])
 def test_upstream_metric_sum(
     river_network, input_field, flow_downstream, mv, array_backend
 ):


### PR DESCRIPTION
### Description
Related to #144. Tests upstream.array.sum for jax, numpy, torch, tensorflow (all cpu). mlx currently avoided for ci due to install issue, but passing locally.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 