### PR TITLE
fix: length to_source must flow downstream

### DIFF
--- a/src/earthkit/hydro/length/array/_toplevel.py
+++ b/src/earthkit/hydro/length/array/_toplevel.py
@@ -176,9 +176,9 @@ def to_source(
     """
     locations = river_network.sources
     if path == "longest":
-        return max(river_network, locations, field, True, False, return_type)
+        return max(river_network, locations, field, False, True, return_type)
     elif path == "shortest":
-        return min(river_network, locations, field, True, False, return_type)
+        return min(river_network, locations, field, False, True, return_type)
     else:
         raise ValueError("path must be 'longest' or 'shortest'")
 


### PR DESCRIPTION
### Description
Length to source must flow **downstream** from the sources. This fixes a bug where it flows **upstream** from the sources, leading to incorrect results.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 