### PR TITLE
Feat/add nightly gpu ci

### DIFF
--- a/.github/ci-hpc-gpu-config.yml
+++ b/.github/ci-hpc-gpu-config.yml
@@ -1,0 +1,7 @@
+build:
+  modules:
+  - rust
+  python_dependencies:
+  - ecmwf/earthkit-data@develo
+  queue: ng
+  gpus: 1

--- a/.github/ci-hpc-gpu-config.yml
+++ b/.github/ci-hpc-gpu-config.yml
@@ -2,6 +2,6 @@ build:
   modules:
   - rust
   python_dependencies:
-  - ecmwf/earthkit-data@develo
+  - ecmwf/earthkit-data@develop
   queue: ng
   gpus: 1

--- a/.github/ci-hpc-gpu-config.yml
+++ b/.github/ci-hpc-gpu-config.yml
@@ -5,3 +5,4 @@ build:
   - ecmwf/earthkit-data@develop
   queue: ng
   gpus: 1
+  toml_opt_dep_sections: all,tests

--- a/.github/workflows/nightly-hpc-gpu.yml
+++ b/.github/workflows/nightly-hpc-gpu.yml
@@ -1,0 +1,21 @@
+name: nightly-hpc-gpu
+
+on:
+  workflow_dispatch:
+
+  # Run at 03:20 UTC every day (on default branch)
+  schedule:
+  - cron: "20 03 * * *"
+
+jobs:
+  test-hpc-gpu:
+    runs-on: [self-hosted, linux, hpc]
+    steps:
+    - uses: ecmwf/reusable-workflows/ci-hpc@v2
+      with:
+        github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
+        github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
+        troika_user: ${{ secrets.HPC_CI_TESTING_SSH_USER }}
+        repository: ecmwf/earthkit-hydro@${{ github.event.pull_request.head.sha || github.sha }}
+        build_config: .github/ci-hpc-gpu-config.yml
+        python_version: "3.10"

--- a/.github/workflows/nightly-hpc-gpu.yml
+++ b/.github/workflows/nightly-hpc-gpu.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         github_user: ${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }}
         github_token: ${{ secrets.GH_REPO_READ_TOKEN }}
-        troika_user: ${{ secrets.HPC_CI_TESTING_SSH_USER }}
+        troika_user: ${{ secrets.HPC_TEST_USER }}
         repository: ecmwf/earthkit-hydro@${{ github.event.pull_request.head.sha || github.sha }}
         build_config: .github/ci-hpc-gpu-config.yml
         python_version: "3.10"


### PR DESCRIPTION
### Description
Adds nightly build using the GPU queue of the HPC. Note that this will not specifically run GPU tests, those will need to be enabled separately, but just the environment is set up in this PR.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 