### PR TITLE
test: verify xarray output preserves location insertion order

### DIFF
--- a/docs/source/howto/specify_locations.rst
+++ b/docs/source/howto/specify_locations.rst
@@ -3,16 +3,16 @@ Specifying locations
 
 Many functions are concerned with operations relating a subset of the entire river network i.e. a fixed number of locations. This can range from catchment averages, to distances etc.
 
-The most convenient and common way to specify a gauge location is by its coordinates, typically latitude and longitude. The specified coordinates must match the river network coordinate system.
+The most convenient and common way to specify a gauge location is by its coordinates, typically latitude and longitude. Coordinates must match the network's coordinate system and be given in the order the network defines its axes, e.g. ``(lat, lon)`` or ``(y, x)``.
 
 For the EFAS network (which uses regular lat/lon) we can specify via the lat/lon of points of interest.
 
 .. code-block:: python
 
     locations = {
-        "station1": (10, 10),
-        "station2": (10, 10),
-        "station3": (10, 10)
+        "station1": (52.3, 4.9),
+        "station2": (51.5, 5.4),
+        "station3": (50.8, 6.1),
     }
 
     labelled_field = ekh.catchments.sum(network, field, locations)

--- a/tests/catchments/xarray/test_node_index_order.py
+++ b/tests/catchments/xarray/test_node_index_order.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+import xarray as xr
+from _test_inputs.accumulation import input_field_1c, upstream_metric_mean_1c
+from _test_inputs.readers import cama_nextxy_1
+
+import earthkit.hydro as ekh
+
+pytestmark = pytest.mark.parametrize(
+    "river_network",
+    [("cama_nextxy", cama_nextxy_1)],
+    indirect=True,
+)
+
+# All three encode the same 5 outlets in the same insertion order
+_OUTLET_NODES = [11, 8, 13, 10, 12]
+_OUTLET_NODES_2D = [(2, 1), (1, 3), (2, 3), (2, 0), (2, 2)]
+_OUTLET_DICT = {"B": (2, 1), "E": (1, 3), "D": (2, 3), "A": (2, 0), "C": (2, 2)}
+_OUTLET_MEANS = upstream_metric_mean_1c[np.array(_OUTLET_NODES)]
+_FIELD_DA = xr.DataArray(
+    input_field_1c.copy(),
+    dims=["node_index"],
+    coords={"node_index": np.arange(len(input_field_1c))},
+)
+
+
+def test_catchment_mean_preserves_location_order_list(river_network):
+    result = ekh.catchments.mean(river_network, _FIELD_DA, locations=_OUTLET_NODES)
+
+    np.testing.assert_array_equal(result.coords["node_index"].values, _OUTLET_NODES)
+    np.testing.assert_allclose(result.values, _OUTLET_MEANS, rtol=1e-6)
+
+
+def test_catchment_mean_preserves_location_order_2d(river_network):
+    result = ekh.catchments.mean(river_network, _FIELD_DA, locations=_OUTLET_NODES_2D)
+
+    np.testing.assert_array_equal(result.coords["node_index"].values, _OUTLET_NODES)
+    np.testing.assert_array_equal(result.coords["y"].values, [t[0] for t in _OUTLET_NODES_2D])
+    np.testing.assert_array_equal(result.coords["x"].values, [t[1] for t in _OUTLET_NODES_2D])
+    np.testing.assert_allclose(result.values, _OUTLET_MEANS, rtol=1e-6)
+
+
+def test_catchment_mean_preserves_location_order_dict(river_network):
+    result = ekh.catchments.mean(river_network, _FIELD_DA, locations=_OUTLET_DICT)
+
+    np.testing.assert_array_equal(result.coords["node_index"].values, _OUTLET_NODES)
+    np.testing.assert_array_equal(result.coords["name"].values, list(_OUTLET_DICT.keys()))
+    np.testing.assert_allclose(result.values, _OUTLET_MEANS, rtol=1e-6)

--- a/tests/catchments/xarray/test_node_index_order.py
+++ b/tests/catchments/xarray/test_node_index_order.py
@@ -35,8 +35,12 @@ def test_catchment_mean_preserves_location_order_2d(river_network):
     result = ekh.catchments.mean(river_network, _FIELD_DA, locations=_OUTLET_NODES_2D)
 
     np.testing.assert_array_equal(result.coords["node_index"].values, _OUTLET_NODES)
-    np.testing.assert_array_equal(result.coords["y"].values, [t[0] for t in _OUTLET_NODES_2D])
-    np.testing.assert_array_equal(result.coords["x"].values, [t[1] for t in _OUTLET_NODES_2D])
+    np.testing.assert_array_equal(
+        result.coords["y"].values, [t[0] for t in _OUTLET_NODES_2D]
+    )
+    np.testing.assert_array_equal(
+        result.coords["x"].values, [t[1] for t in _OUTLET_NODES_2D]
+    )
     np.testing.assert_allclose(result.values, _OUTLET_MEANS, rtol=1e-6)
 
 
@@ -44,5 +48,7 @@ def test_catchment_mean_preserves_location_order_dict(river_network):
     result = ekh.catchments.mean(river_network, _FIELD_DA, locations=_OUTLET_DICT)
 
     np.testing.assert_array_equal(result.coords["node_index"].values, _OUTLET_NODES)
-    np.testing.assert_array_equal(result.coords["name"].values, list(_OUTLET_DICT.keys()))
+    np.testing.assert_array_equal(
+        result.coords["name"].values, list(_OUTLET_DICT.keys())
+    )
     np.testing.assert_allclose(result.values, _OUTLET_MEANS, rtol=1e-6)


### PR DESCRIPTION
### Description

Adds tests asserting that catchment results preserve the insertion order of the `locations` argument across all three input types (1D list, 2D list, dict). 

Also proposes clarifying axis ordering requirements for location coordinates.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
