### PR TITLE
Feat/export

### DIFF
--- a/src/earthkit/hydro/_readers/_core.py
+++ b/src/earthkit/hydro/_readers/_core.py
@@ -31,7 +31,7 @@ def import_earthkit_or_prompt_install(river_network_format, source):
         import earthkit.data as ekd
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
-            "earthkit-data is required for loading river network format"
+            "earthkit-data is required for loading river network format "
             f"{river_network_format} from source {source}."
             "\nTo install it, run `pip install earthkit-data`"
         )

--- a/src/earthkit/hydro/data_structures/_network.py
+++ b/src/earthkit/hydro/data_structures/_network.py
@@ -147,6 +147,9 @@ class RiverNetwork:
         """
         Save the river network to a local file.
 
+        .. warning::
+            This is not recommended. Please use `earthkit.hydro.river_network.export` instead.
+
         Parameters
         ----------
         fpath : str, optional

--- a/src/earthkit/hydro/river_network/__init__.py
+++ b/src/earthkit/hydro/river_network/__init__.py
@@ -1,4 +1,5 @@
+from ._export import export
 from ._repair import repair
 from ._river_network import available, create, load
 
-__all__ = ["available", "create", "load", "repair"]
+__all__ = ["available", "create", "export", "load", "repair"]

--- a/src/earthkit/hydro/river_network/_export.py
+++ b/src/earthkit/hydro/river_network/_export.py
@@ -11,6 +11,33 @@ def export(
     river_network_format: str = "precomputed",
     compression=1,
 ):
+    """
+    Export a river network to a local file.
+
+    .. note::
+        Exporting to precomputed format is highly recommended for efficiency reasons.
+        Other river network formats should only be used if compatibility is required with other tooling.
+
+    .. note::
+        For formats other than precomputed, only exporting as netcdf is currently supported.
+
+    Parameters
+    ----------
+    river_network : RiverNetworkStorage | RiverNetwork
+        The river network to export.
+    path : str
+        Where to export the river network.
+    river_network_format : str
+        The format of the river network data.
+        Currently supported formats are "pcr_d8", "esri_d8"
+        and "merit_d8".
+    compression : int
+        The compression factor to use for the saved file. Only applied if river_network_format is precomputed.
+
+    Returns
+    -------
+    None. Writes the river network to a local file at `path`.
+    """
     if river_network_format not in {"precomputed", "pcr_d8", "esri_d8", "merit_d8"}:
         raise ValueError(f"Exporting river network to format {river_network_format} is not currently supported.")
 
@@ -35,6 +62,11 @@ def export(
     dy = np.zeros(mask.shape, dtype=int)
     dx[u] = (mask[d] % nx) - (mask[u] % nx)
     dy[u] = (mask[d] // nx) - (mask[u] // nx)
+
+    if river_network_format in {"pcr_d8", "esri_d8", "merit_d8"} and not (
+        np.all(np.abs(dx) <= 1) and np.all(np.abs(dy) <= 1)
+    ):
+        raise ValueError("River network is not representable in d8 format.")
 
     # Scatter back to 2D grids
     mv = missing_values[river_network_format]

--- a/src/earthkit/hydro/river_network/_export.py
+++ b/src/earthkit/hydro/river_network/_export.py
@@ -21,6 +21,11 @@ def export(
     .. note::
         For formats other than precomputed, only exporting as netcdf is currently supported.
 
+    .. warning::
+        The cama format has two different sink representations, one for inland sinks (-10), and one for coastal sinks (-9).
+        There is only one sink representation in earthkit-hydro, so for cama format exports all sinks are exported as coastal sinks (-9).
+        This does not change any results with earthkit-hydro, but be aware when using other tools.
+
     Parameters
     ----------
     river_network : RiverNetworkStorage | RiverNetwork
@@ -38,7 +43,7 @@ def export(
     -------
     None. Writes the river network to a local file at `path`.
     """
-    if river_network_format not in {"precomputed", "pcr_d8", "esri_d8", "merit_d8"}:
+    if river_network_format not in {"precomputed", "pcr_d8", "esri_d8", "merit_d8", "cama"}:
         raise ValueError(f"Exporting river network to format {river_network_format} is not currently supported.")
 
     river_network_storage = river_network if isinstance(river_network, RiverNetworkStorage) else river_network._storage
@@ -49,11 +54,14 @@ def export(
         joblib.dump(river_network_storage, path, compress=compression)
         return
 
-    missing_values = {"pcr_d8": 255, "esri_d8": 255, "merit_d8": 247}
+    missing_values = {"pcr_d8": 255, "esri_d8": 255, "merit_d8": 247, "cama": -9999}
 
     d, u, _ = river_network_storage.sorted_data
     mask = river_network_storage.mask
     coords = river_network_storage.coords
+
+    if coords is None:
+        raise ValueError("River network does not have coordinates.")
 
     shape = river_network_storage.shape
     _, nx = shape
@@ -68,8 +76,38 @@ def export(
     ):
         raise ValueError("River network is not representable in d8 format.")
 
-    # Scatter back to 2D grids
     mv = missing_values[river_network_format]
+
+    if river_network_format == "cama":
+        sinks = (dx == 0) & (dy == 0)
+        cols, rows = np.indices(shape)
+        rows = rows.flat[mask]
+        cols = cols.flat[mask]
+
+        x_masked = ((rows + dx) % shape[1]) + 1
+        x_masked[sinks] = -9
+        del dx, rows
+        x = np.full(shape, mv, dtype=np.int32)
+        x.flat[mask] = x_masked
+        del x_masked
+
+        y_masked = ((cols + dy) % shape[0]) + 1
+        y_masked[sinks] = -9
+        del dy, cols
+        y = np.full(shape, mv, dtype=np.int32)
+        y.flat[mask] = y_masked
+        del y_masked
+
+        coord1, coord2 = coords.keys()
+        da_x = xr.DataArray(x, dims=(coord1, coord2), coords=coords, name="nextx")
+        da_x = _encode_da(da_x, mv)
+        da_y = xr.DataArray(y, dims=(coord1, coord2), coords=coords, name="nexty")
+        da_y = _encode_da(da_y, mv)
+        ds = xr.Dataset({"nextx": da_x, "nexty": da_y})
+        ds.to_netcdf(path)
+        return
+
+    # Scatter back to 2D grids
     data = np.full(shape, mv, dtype=np.uint8)
 
     if river_network_format == "pcr_d8":
@@ -98,13 +136,16 @@ def export(
             data.flat[mask] = lut[dy + 1, dx + 1]
         except Exception as e:
             raise ValueError("Failed to represent river network as D8") from e
-    else:
-        raise ValueError(f"Unsupported river network format for the export method: {river_network_format}.")
 
     coord1, coord2 = coords.keys()
     da = xr.DataArray(data.astype(np.uint8), dims=(coord1, coord2), coords=coords, name="ldd")
+    da = _encode_da(da, mv)
+    da.to_netcdf(path)
+
+
+def _encode_da(da, mv):
     da.attrs["generated_by"] = "earthkit-hydro"
     da.encoding = {
         "_FillValue": mv,
     }
-    da.to_netcdf(path)
+    return da

--- a/src/earthkit/hydro/river_network/_export.py
+++ b/src/earthkit/hydro/river_network/_export.py
@@ -64,12 +64,17 @@ def export(
         raise ValueError("River network does not have coordinates.")
 
     shape = river_network_storage.shape
-    _, nx = shape
+    ny, nx = shape
 
     dx = np.zeros(mask.shape, dtype=int)
+    temp_dx = (mask[d] % nx) - (mask[u] % nx)
+    dx[u] = (temp_dx + nx // 2) % nx - nx // 2
+    del temp_dx
+
     dy = np.zeros(mask.shape, dtype=int)
-    dx[u] = (mask[d] % nx) - (mask[u] % nx)
-    dy[u] = (mask[d] // nx) - (mask[u] // nx)
+    temp_dy = (mask[d] // nx) - (mask[u] // nx)
+    dy[u] = (temp_dy + ny // 2) % ny - ny // 2
+    del temp_dy
 
     if river_network_format in {"pcr_d8", "esri_d8", "merit_d8"} and not (
         np.all(np.abs(dx) <= 1) and np.all(np.abs(dy) <= 1)

--- a/src/earthkit/hydro/river_network/_export.py
+++ b/src/earthkit/hydro/river_network/_export.py
@@ -66,15 +66,18 @@ def export(
     shape = river_network_storage.shape
     ny, nx = shape
 
+    def shortest_offset(delta, n):
+        # return (delta + n // 2) % n - n // 2 # negatives win ties
+        # positives win ties
+        delta = delta % n
+        delta[delta > n // 2] -= n
+        return delta
+
     dx = np.zeros(mask.shape, dtype=int)
-    temp_dx = (mask[d] % nx) - (mask[u] % nx)
-    dx[u] = (temp_dx + nx // 2) % nx - nx // 2
-    del temp_dx
+    dx[u] = shortest_offset((mask[d] % nx) - (mask[u] % nx), nx)
 
     dy = np.zeros(mask.shape, dtype=int)
-    temp_dy = (mask[d] // nx) - (mask[u] // nx)
-    dy[u] = (temp_dy + ny // 2) % ny - ny // 2
-    del temp_dy
+    dy[u] = shortest_offset((mask[d] // nx) - (mask[u] // nx), ny)
 
     if river_network_format in {"pcr_d8", "esri_d8", "merit_d8"} and not (
         np.all(np.abs(dx) <= 1) and np.all(np.abs(dy) <= 1)

--- a/src/earthkit/hydro/river_network/_export.py
+++ b/src/earthkit/hydro/river_network/_export.py
@@ -46,6 +46,9 @@ def export(
     if river_network_format not in {"precomputed", "pcr_d8", "esri_d8", "merit_d8", "cama"}:
         raise ValueError(f"Exporting river network to format {river_network_format} is not currently supported.")
 
+    if isinstance(river_network, RiverNetwork) and river_network.array_backend != "numpy":
+        raise ValueError("Exporting for non-numpy backend not supported.")
+
     river_network_storage = river_network if isinstance(river_network, RiverNetworkStorage) else river_network._storage
 
     if river_network_format == "precomputed":

--- a/src/earthkit/hydro/river_network/_repair.py
+++ b/src/earthkit/hydro/river_network/_repair.py
@@ -75,8 +75,9 @@ def repair(input_path, output_path, river_network_format, input_source="file"):
     """
     Given an initial river network, repairs the river network and writes the output to local file.
 
-    Warning: this function should only be used by advanced users.
-    It should not be used without an understanding of why the initial river network needs reparation.
+    .. warning::
+        This function should only be used by advanced users.
+        It should not be used without an understanding of why the initial river network needs repair.
 
     The repairing algorithm is as follows:
 

--- a/tests/river_network/test_export.py
+++ b/tests/river_network/test_export.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pytest
+import xarray as xr
+from _test_inputs.readers import *
+
+import earthkit.hydro as ekh
+
+
+def generate_ldd(data, mv):
+    if isinstance(data, tuple):
+        x, y = data
+
+        coords = {"lat": np.arange(x.shape[0]), "lon": np.arange(x.shape[1])}
+
+        coord1, coord2 = coords.keys()
+        da_x = xr.DataArray(x, dims=(coord1, coord2), coords=coords, name="nextx")
+        da_x.encoding = {
+            "_FillValue": mv,
+        }
+        da_y = xr.DataArray(y, dims=(coord1, coord2), coords=coords, name="nexty")
+        da_y.encoding = {
+            "_FillValue": mv,
+        }
+        return xr.Dataset({"nextx": da_x, "nexty": da_y})
+
+    else:
+        coords = {"lat": np.arange(data.shape[0]), "lon": np.arange(data.shape[1])}
+        coord1, coord2 = coords
+        da = xr.DataArray(data.astype(np.int32), dims=(coord1, coord2), coords=coords, name="ldd")
+        da.encoding = {
+            "_FillValue": mv,
+        }
+        return da
+
+
+@pytest.mark.parametrize(
+    "ldd, mv, river_network_format",
+    [
+        (d8_ldd_1, 255, "pcr_d8"),
+        (cama_nextxy_1, -9, "cama"),
+        (d8_ldd_2, 255, "pcr_d8"),
+        (cama_nextxy_2, -9, "cama"),
+    ],
+)
+def test_create_export(tmp_path, ldd, mv, river_network_format):
+    original = str(tmp_path / "original.nc")
+    ds = generate_ldd(ldd, mv)
+    ds.to_netcdf(original)
+
+    net = ekh.river_network.create(original, river_network_format)
+
+    original_sum = ekh.upstream.sum(net, np.arange(net.n_nodes))
+
+    exported_pcr = str(tmp_path / "exported_pcr.nc")
+    exported_cama = str(tmp_path / "exported_cama.nc")
+    exported_merit = str(tmp_path / "exported_merit.nc")
+    exported_esri = str(tmp_path / "exported_esri.nc")
+
+    export_options = [
+        (exported_pcr, "pcr_d8"),
+        (exported_cama, "cama"),
+        (exported_merit, "merit_d8"),
+        (exported_esri, "esri_d8"),
+    ]
+
+    for file, fmt in export_options:
+        ekh.river_network.export(net, file, fmt)
+        net = ekh.river_network.create(file, fmt)
+        exported_sum = ekh.upstream.sum(net, np.arange(net.n_nodes))
+        np.testing.assert_array_equal(original_sum, exported_sum)

--- a/tests/river_network/test_repair.py
+++ b/tests/river_network/test_repair.py
@@ -980,7 +980,7 @@ OUTPUT4 = generate_ldd(data)
         (INPUT4, OUTPUT4, "esri_d8"),
     ],
 )
-def test_repair_file(tmp_path, input_da, output_da, fmt):
+def test_repair(tmp_path, input_da, output_da, fmt):
     input_file = str(tmp_path / "input.txt")
     output_file = str(tmp_path / "output.txt")
 


### PR DESCRIPTION
### Description
New API for exports.
```python
ekh.river_network.export(river_network, path, river_network_format)
```

Supports exporting as precomputed (recommended), pcr_d8, esri_d8, merit_d8 and also cama (nextxy).

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
